### PR TITLE
fix: improve dial encoder responsiveness

### DIFF
--- a/boards/arm/eyelash_corne/eyelash_corne.dtsi
+++ b/boards/arm/eyelash_corne/eyelash_corne.dtsi
@@ -41,13 +41,13 @@
         compatible = "alps,ec11";
         a-gpios = <&gpio1 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&gpio1 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
-        steps = <30>;
+        steps = <15>;
         status = "disabled";
     };
 
     sensors {
         compatible = "zmk,keymap-sensors";
-        triggers-per-rotation = <15>;
+        triggers-per-rotation = <60>;
         sensors = <&left_encoder>;
     };
 


### PR DESCRIPTION
This increases the responsiveness of the dial encoder to 1 activation per step.